### PR TITLE
Local disk "omitempty" tiny fix

### DIFF
--- a/data_types/softlayer_virtual_guest.go
+++ b/data_types/softlayer_virtual_guest.go
@@ -29,7 +29,7 @@ type SoftLayer_Virtual_Guest struct {
 	StartCpus                    int        `json:"startCpus,omitempty"`
 	StatusId                     int        `json:"statusId,omitempty"`
 	Uuid                         string     `json:"uuid,omitempty"`
-	LocalDiskFlag                bool       `json:"localDiskFlag",omitempty`
+	LocalDiskFlag                bool       `json:"localDiskFlag,omitempty"`
 	HourlyBillingFlag 			 bool       `json:"hourlyBillingFlag,omitempty"`
 
 	GlobalIdentifier        string `json:"globalIdentifier,omitempty"`


### PR DESCRIPTION
Tiny fix which may affect the "vetting" phase of Travis build after running `softlayer-go` tests.
