### PR TITLE
Create interface for User_Customer SoftLayer service api

### DIFF
--- a/client/fakes/softlayer_client_fake.go
+++ b/client/fakes/softlayer_client_fake.go
@@ -69,6 +69,15 @@ func (fslc *FakeSoftLayerClient) GetSoftLayer_Account_Service() (softlayer.SoftL
 	return slService.(softlayer.SoftLayer_Account_Service), nil
 }
 
+func (slc *FakeSoftLayerClient) GetSoftLayer_User_Customer_Service() (softlayer.SoftLayer_User_Customer_Service, error) {
+	slService, err := slc.GetService("SoftLayer_User_Customer")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_User_Customer_Service), nil
+}
+
 func (fslc *FakeSoftLayerClient) GetSoftLayer_Virtual_Guest_Service() (softlayer.SoftLayer_Virtual_Guest_Service, error) {
 	slService, err := fslc.GetService("SoftLayer_Virtual_Guest")
 	if err != nil {
@@ -284,6 +293,7 @@ func (fslc *FakeSoftLayerClient) CheckForHttpResponseErrors(data []byte) error {
 
 func (fslc *FakeSoftLayerClient) initSoftLayerServices() {
 	fslc.SoftLayerServices["SoftLayer_Account"] = services.NewSoftLayer_Account_Service(fslc)
+	fslc.SoftLayerServices["SoftLayer_User_Customer"] = services.NewSoftLayer_User_Customer_Service(fslc)
 	fslc.SoftLayerServices["SoftLayer_Virtual_Guest"] = services.NewSoftLayer_Virtual_Guest_Service(fslc)
 	fslc.SoftLayerServices["SoftLayer_Virtual_Disk_Image"] = services.NewSoftLayer_Virtual_Disk_Image_Service(fslc)
 	fslc.SoftLayerServices["SoftLayer_Security_Ssh_Key"] = services.NewSoftLayer_Security_Ssh_Key_Service(fslc)

--- a/client/fakes/softlayer_client_fake.go
+++ b/client/fakes/softlayer_client_fake.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"bytes"
 
-	services "github.com/TheWeatherCompany/softlayer-go/services"
-	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+	"github.com/TheWeatherCompany/softlayer-go/services"
+	"github.com/TheWeatherCompany/softlayer-go/softlayer"
 )
 
 const (
@@ -23,7 +24,7 @@ type FakeSoftLayerClient struct {
 
 	SoftLayerServices map[string]softlayer.Service
 
-	FakeHttpClient *FakeHttpClient
+	*FakeHttpClient
 }
 
 func NewFakeSoftLayerClient(username, apiKey string) *FakeSoftLayerClient {
@@ -182,7 +183,7 @@ func (fslc *FakeSoftLayerClient) GetSoftLayer_Dns_Domain_ResourceRecord_Service(
 		return nil, err
 	}
 
-	return slService.(softlayer.SoftLayer_Dns_Domain_Record_Service), nil
+	return slService.(softlayer.SoftLayer_Dns_Domain_ResourceRecord_Service), nil
 }
 
 func (fslc *FakeSoftLayerClient) GetSoftLayer_Network_Application_Delivery_Controller_Service() (softlayer.SoftLayer_Network_Application_Delivery_Controller_Service, error) {
@@ -199,7 +200,7 @@ func (fslc *FakeSoftLayerClient) DoRawHttpRequestWithObjectMask(path string, mas
 	fslc.DoRawHttpRequestPath = path
 	fslc.DoRawHttpRequestRequestType = requestType
 
-	fslc.DoRawHttpRequestResponseCount += 1
+	fslc.DoRawHttpRequestResponsesCount += 1
 
 	if fslc.DoRawHttpRequestError != nil {
 		return []byte{}, fslc.DoRawHttpRequestError
@@ -217,7 +218,7 @@ func (fslc *FakeSoftLayerClient) DoRawHttpRequestWithObjectFilter(path string, f
 	fslc.DoRawHttpRequestPath = path
 	fslc.DoRawHttpRequestRequestType = requestType
 
-	fslc.DoRawHttpRequestResponseCount += 1
+	fslc.DoRawHttpRequestResponsesCount += 1
 
 	if fslc.DoRawHttpRequestError != nil {
 		return []byte{}, fslc.DoRawHttpRequestError
@@ -235,7 +236,7 @@ func (fslc *FakeSoftLayerClient) DoRawHttpRequestWithObjectFilterAndObjectMask(p
 	fslc.DoRawHttpRequestPath = path
 	fslc.DoRawHttpRequestRequestType = requestType
 
-	fslc.DoRawHttpRequestResponseCount += 1
+	fslc.DoRawHttpRequestResponsesCount += 1
 
 	if fslc.DoRawHttpRequestError != nil {
 		return []byte{}, fslc.DoRawHttpRequestError
@@ -253,7 +254,7 @@ func (fslc *FakeSoftLayerClient) DoRawHttpRequest(path string, requestType strin
 	fslc.DoRawHttpRequestPath = path
 	fslc.DoRawHttpRequestRequestType = requestType
 
-	fslc.DoRawHttpRequestResponseCount += 1
+	fslc.DoRawHttpRequestResponsesCount += 1
 
 	if fslc.DoRawHttpRequestError != nil {
 		return []byte{}, fslc.DoRawHttpRequestError
@@ -276,7 +277,7 @@ func (fslc *FakeSoftLayerClient) HasErrors(body map[string]interface{}) error {
 }
 
 func (fslc *FakeSoftLayerClient) CheckForHttpResponseErrors(data []byte) error {
-	return slService.(softlayer.SoftLayer_Dns_Domain_ResourceRecord_Service), nil
+	return fslc.CheckForHttpResponseErrorsError
 }
 
 //Private methods

--- a/client/softlayer_client.go
+++ b/client/softlayer_client.go
@@ -66,6 +66,15 @@ func (slc *SoftLayerClient) GetSoftLayer_Account_Service() (softlayer.SoftLayer_
 	return slService.(softlayer.SoftLayer_Account_Service), nil
 }
 
+func (slc *SoftLayerClient) GetSoftLayer_User_Customer_Service() (softlayer.SoftLayer_User_Customer_Service, error) {
+	slService, err := slc.GetService("SoftLayer_User_Customer")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_User_Customer_Service), nil
+}
+
 func (slc *SoftLayerClient) GetSoftLayer_Virtual_Guest_Service() (softlayer.SoftLayer_Virtual_Guest_Service, error) {
 	slService, err := slc.GetService("SoftLayer_Virtual_Guest")
 	if err != nil {
@@ -241,6 +250,7 @@ func (slc *SoftLayerClient) DoRawHttpRequest(path string, requestType string, re
 
 func (slc *SoftLayerClient) initSoftLayerServices() {
 	slc.softLayerServices["SoftLayer_Account"] = services.NewSoftLayer_Account_Service(slc)
+	slc.softLayerServices["SoftLayer_User_Customer"] = services.NewSoftLayer_User_Customer_Service(slc)
 	slc.softLayerServices["SoftLayer_Virtual_Guest"] = services.NewSoftLayer_Virtual_Guest_Service(slc)
 	slc.softLayerServices["SoftLayer_Virtual_Disk_Image"] = services.NewSoftLayer_Virtual_Disk_Image_Service(slc)
 	slc.softLayerServices["SoftLayer_Security_Ssh_Key"] = services.NewSoftLayer_Security_Ssh_Key_Service(slc)

--- a/data_types/softlayer_user_customer.go
+++ b/data_types/softlayer_user_customer.go
@@ -9,3 +9,9 @@ type SoftLayer_User_Customer struct {
 	LastName    string `json:"lastName"`
 	ParentId    int    `json:"parentId"`
 }
+
+type SoftLayer_User_Customer_ApiAuthentication struct {
+	Id                int    `json:"id"`
+	AuthenticationKey string `json:"authenticationKey"`
+	UserId            int    `json:"userId"`
+}

--- a/data_types/softlayer_user_customer.go
+++ b/data_types/softlayer_user_customer.go
@@ -1,0 +1,11 @@
+package data_types
+
+type SoftLayer_User_Customer struct {
+	Id          int    `json:"id"`
+	Username    string `json:"username"`
+	DisplayName string `json:"displayName"`
+	Email       string `json:"email"`
+	FirstName   string `json:"firstName"`
+	LastName    string `json:"lastName"`
+	ParentId    int    `json:"parentId"`
+}

--- a/services/softLayer_account.go
+++ b/services/softLayer_account.go
@@ -49,6 +49,31 @@ func (slas *softLayer_Account_Service) GetAccountStatus() (datatypes.SoftLayer_A
 	return accountStatus, nil
 }
 
+func (slas *softLayer_Account_Service) GetUsers() ([]datatypes.SoftLayer_User_Customer, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getUsers.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getUsers, error message '%s'", err.Error())
+		return nil, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getUsers, HTTP error code: '%d'", errorCode)
+		return nil, errors.New(errorMessage)
+	}
+
+	users := []datatypes.SoftLayer_User_Customer{}
+	if err = json.Unmarshal(responseBytes, &users); err != nil {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: failed to decode SoftLayer_Account#getUsers JSON response, error message: '%s'",
+			err.Error(),
+		)
+		return nil, errors.New(errorMessage)
+	}
+
+	return users, nil
+}
+
 func (slas *softLayer_Account_Service) GetVirtualGuests() ([]datatypes.SoftLayer_Virtual_Guest, error) {
 	path := fmt.Sprintf("%s/%s", slas.GetName(), "getVirtualGuests.json")
 	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})

--- a/services/softlayer_account_test.go
+++ b/services/softlayer_account_test.go
@@ -79,6 +79,43 @@ var _ = Describe("SoftLayer_Account_Service", func() {
 		})
 	})
 
+	Context("#GetUsers", func() {
+		BeforeEach(func() {
+			fakeClient.FakeHttpClient.DoRawHttpRequestResponse, err =
+				testhelpers.ReadJsonTestFixtures("services", "SoftLayer_Account_Service_getUsers.json")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an array of datatypes.SoftLayer_User_Customer", func() {
+			users, err := accountService.GetUsers()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(users[0].Id).ToNot(Equal(0))
+			Expect(users[0].FirstName).To(Equal("Joe"))
+		})
+
+		Context("when HTTP client returns error codes 40x or 50x", func() {
+			It("fails for error code 40x", func() {
+				errorCodes := []int{400, 401, 499}
+				for _, errorCode := range errorCodes {
+					fakeClient.FakeHttpClient.DoRawHttpRequestInt = errorCode
+
+					_, err := accountService.GetUsers()
+					Expect(err).To(HaveOccurred())
+				}
+			})
+
+			It("fails for error code 50x", func() {
+				errorCodes := []int{500, 501, 599}
+				for _, errorCode := range errorCodes {
+					fakeClient.FakeHttpClient.DoRawHttpRequestInt = errorCode
+
+					_, err := accountService.GetUsers()
+					Expect(err).To(HaveOccurred())
+				}
+			})
+		})
+	})
+
 	Context("#GetVirtualGuests", func() {
 		BeforeEach(func() {
 			fakeClient.FakeHttpClient.DoRawHttpRequestResponse, err = testhelpers.ReadJsonTestFixtures("services", "SoftLayer_Account_Service_getVirtualGuests.json")

--- a/services/softlayer_user_customer.go
+++ b/services/softlayer_user_customer.go
@@ -1,0 +1,80 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/TheWeatherCompany/softlayer-go/common"
+	"github.com/TheWeatherCompany/softlayer-go/data_types"
+	"github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softlayer_user_customer_service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_User_Customer_Service(client softlayer.Client) *softlayer_user_customer_service {
+	return &softlayer_user_customer_service{
+		client: client,
+	}
+}
+
+func (slucs *softlayer_user_customer_service) GetName() string {
+	return "SoftLayer_User_Customer"
+}
+
+func (slucs *softlayer_user_customer_service) GetApiAuthenticationKeys(userId int) ([]data_types.SoftLayer_User_Customer_ApiAuthentication, error) {
+	path := fmt.Sprintf("%s/%d/%s", slucs.GetName(), userId, "getApiAuthenticationKeys.json")
+	responseBytes, errorCode, err := slucs.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#getApiAuthenticationKeys, error message '%s'",
+			slucs.GetName(), err.Error(),
+		)
+		return nil, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#getApiAuthenticationKeys, HTTP error code: '%d'",
+			slucs.GetName(), errorCode,
+		)
+		return nil, errors.New(errorMessage)
+	}
+
+	apiKeys := []data_types.SoftLayer_User_Customer_ApiAuthentication{}
+	err = json.Unmarshal(responseBytes, &apiKeys)
+	if err != nil {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: failed to decode JSON response from %s#getApiAuthenticationKeys, err message '%s'",
+			slucs.GetName(), err.Error(),
+		)
+		err := errors.New(errorMessage)
+		return nil, err
+	}
+
+	return apiKeys, nil
+}
+
+func (slucs *softlayer_user_customer_service) AddApiAuthenticationKey(userId int) error {
+	path := fmt.Sprintf("%s/%d/%s", slucs.GetName(), userId, "addApiAuthenticationKey.json")
+	_, errorCode, err := slucs.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#addApiAuthenticationKey, error message '%s'",
+			slucs.GetName(), err.Error(),
+		)
+		return errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#addApiAuthenticationKey, HTTP error code: '%d'",
+			slucs.GetName(), errorCode,
+		)
+		return errors.New(errorMessage)
+	}
+
+	return nil
+}

--- a/services/softlayer_user_customer_test.go
+++ b/services/softlayer_user_customer_test.go
@@ -1,0 +1,64 @@
+package services_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	clientfakes "github.com/TheWeatherCompany/softlayer-go/client/fakes"
+	"github.com/TheWeatherCompany/softlayer-go/softlayer"
+	"github.com/TheWeatherCompany/softlayer-go/test_helpers"
+)
+
+var _ = Describe("SoftLayer_User_Customer_Service", func() {
+	var (
+		username, apiKey    string
+		fakeClient          *clientfakes.FakeSoftLayerClient
+		userCustomerService softlayer.SoftLayer_User_Customer_Service
+		err                 error
+	)
+
+	BeforeEach(func() {
+		username = os.Getenv("SL_USERNAME")
+		Expect(username).ToNot(Equal(""))
+
+		apiKey = os.Getenv("SL_API_KEY")
+		Expect(apiKey).ToNot(Equal(""))
+
+		fakeClient = clientfakes.NewFakeSoftLayerClient(username, apiKey)
+		Expect(fakeClient).ToNot(BeNil())
+
+		userCustomerService, err = fakeClient.GetSoftLayer_User_Customer_Service()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(userCustomerService).ToNot(BeNil())
+	})
+
+	Context("#GetApiAuthenticationKeys", func() {
+		BeforeEach(func() {
+			fakeClient.FakeHttpClient.DoRawHttpRequestResponse, err =
+				test_helpers.ReadJsonTestFixtures("services", "SoftLayer_User_Customer_getApiAuthenticationKeys.json")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an array of datatypes.SoftLayer_User_Customer_ApiAuthentication", func() {
+			authKeys, err := userCustomerService.GetApiAuthenticationKeys(0)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(authKeys)).ToNot(Equal(0))
+			Expect(authKeys[0].AuthenticationKey).To(Equal("0123456789"))
+		})
+	})
+
+	Context("#AddApiAuthenticationKey", func() {
+		BeforeEach(func() {
+			fakeClient.FakeHttpClient.DoRawHttpRequestResponse, err =
+				test_helpers.ReadJsonTestFixtures("services", "SoftLayer_User_Customer_addApiAuthenticationKey.json")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("adds an api authentication key to a softlayer user", func() {
+			err := userCustomerService.AddApiAuthenticationKey(0)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/softlayer/client.go
+++ b/softlayer/client.go
@@ -8,6 +8,7 @@ type Client interface {
 	GetService(name string) (Service, error)
 
 	GetSoftLayer_Account_Service() (SoftLayer_Account_Service, error)
+	GetSoftLayer_User_Customer_Service() (SoftLayer_User_Customer_Service, error)
 	GetSoftLayer_Virtual_Guest_Service() (SoftLayer_Virtual_Guest_Service, error)
 	GetSoftLayer_Virtual_Disk_Image_Service() (SoftLayer_Virtual_Disk_Image_Service, error)
 	GetSoftLayer_Security_Ssh_Key_Service() (SoftLayer_Security_Ssh_Key_Service, error)

--- a/softlayer/softlayer_account_service.go
+++ b/softlayer/softlayer_account_service.go
@@ -8,6 +8,7 @@ type SoftLayer_Account_Service interface {
 	Service
 
 	GetAccountStatus() (datatypes.SoftLayer_Account_Status, error)
+	GetUsers() ([]datatypes.SoftLayer_User_Customer, error)
 	GetVirtualGuests() ([]datatypes.SoftLayer_Virtual_Guest, error)
 	GetVirtualGuestsByFilter(filters string) ([]datatypes.SoftLayer_Virtual_Guest, error)
 	GetNetworkStorage() ([]datatypes.SoftLayer_Network_Storage, error)

--- a/softlayer/softlayer_user_customer_service.go
+++ b/softlayer/softlayer_user_customer_service.go
@@ -1,0 +1,12 @@
+package softlayer
+
+import (
+	"github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_User_Customer_Service interface {
+	Service
+
+	AddApiAuthenticationKey(userId int) error
+	GetApiAuthenticationKeys(userId int) ([]data_types.SoftLayer_User_Customer_ApiAuthentication, error)
+}

--- a/test_fixtures/services/SoftLayer_Account_Service_getUsers.json
+++ b/test_fixtures/services/SoftLayer_Account_Service_getUsers.json
@@ -1,0 +1,58 @@
+[
+  {
+    "accountId": 123456,
+    "address1": "10 Some Street",
+    "city": "Somers",
+    "companyName": "Some Name",
+    "country": "US",
+    "createDate": "2015-09-30T08:29:43-05:00",
+    "daylightSavingsTimeFlag": true,
+    "denyAllResourceAccessOnCreateFlag": false,
+    "displayName": "JDoe",
+    "email": "jdoe@foo.bar",
+    "firstName": "Joe",
+    "forumPasswordHash": "****************",
+    "id": 123456,
+    "lastName": "Doe",
+    "localeId": 1,
+    "managedByFederationFlag": false,
+    "managedByOIDCFlag": false,
+    "modifyDate": "2016-01-29T11:34:39-05:00",
+    "officePhone": "555-555-5555",
+    "parentId": null,
+    "passwordExpireDate": null,
+    "permissionSystemVersion": 2,
+    "postalCode": "123456",
+    "pptpVpnAllowedFlag": false,
+    "savedId": "123456",
+    "secondaryLoginManagementFlag": null,
+    "secondaryLoginRequiredFlag": null,
+    "secondaryPasswordModifyDate": "2015-09-30T15:06:39-05:00",
+    "secondaryPasswordTimeoutDays": null,
+    "sslVpnAllowedFlag": false,
+    "state": "NY",
+    "statusDate": "2015-09-30T08:29:43-05:00",
+    "timezoneId": 114,
+    "userStatusId": 1001,
+    "username": "jdoe123foo",
+    "vpnManualConfig": false,
+    "locale": {
+      "friendlyName": "English",
+      "id": 1,
+      "languageTag": "en-US",
+      "name": "English"
+    },
+    "timezone": {
+      "id": 114,
+      "longName": "(GMT-06:00) America/Dallas - CST",
+      "name": "America/Chicago",
+      "offset": "-0600",
+      "shortName": "CST"
+    },
+    "userStatus": {
+      "id": 1001,
+      "keyName": "ACTIVE",
+      "name": "Active"
+    }
+  }
+]

--- a/test_fixtures/services/SoftLayer_User_Customer_getApiAuthenticationKeys.json
+++ b/test_fixtures/services/SoftLayer_User_Customer_getApiAuthenticationKeys.json
@@ -1,0 +1,8 @@
+[
+  {
+    "authenticationKey": "0123456789",
+    "id": 0,
+    "timestampKey": 1462477384,
+    "userId": 0
+  }
+]


### PR DESCRIPTION
- Adds a GetUsers() method to the account service
- Fixes errors in the fake client module, so that we can run tests on the services module.
- Adds a User_Customer service abstraction with a couple of api auth key methods (add key and get key).
- Includes unit tests
